### PR TITLE
suppress ViewPropTypes warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,99 @@
 {
 	"name": "react-native-parallax-scroll-view",
 	"version": "0.21.3",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "react-native-parallax-scroll-view",
+			"version": "0.21.3",
+			"license": "ISC",
+			"dependencies": {
+				"deprecated-react-native-prop-types": "^2.3.0",
+				"prop-types": "^15.6.0"
+			}
+		},
+		"node_modules/@react-native/normalize-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.0.0.tgz",
+			"integrity": "sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw=="
+		},
+		"node_modules/deprecated-react-native-prop-types": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+			"integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+			"dependencies": {
+				"@react-native/normalize-color": "*",
+				"invariant": "*",
+				"prop-types": "*"
+			}
+		},
+		"node_modules/invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dependencies": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+		},
+		"node_modules/loose-envify": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+			"dependencies": {
+				"js-tokens": "^3.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/prop-types": {
+			"version": "15.6.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+			"integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+			"dependencies": {
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
+			}
+		}
+	},
 	"dependencies": {
+		"@react-native/normalize-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.0.0.tgz",
+			"integrity": "sha512-Wip/xsc5lw8vsBlmY2MO/gFLp3MvuZ2baBZjDeTjjndMgM0h5sxz7AZR62RDPGgstp8Np7JzjvVqVT7tpFZqsw=="
+		},
+		"deprecated-react-native-prop-types": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+			"integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+			"requires": {
+				"@react-native/normalize-color": "*",
+				"invariant": "*",
+				"prop-types": "*"
+			}
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"author": "Jack Hsu",
 	"license": "ISC",
 	"dependencies": {
+		"deprecated-react-native-prop-types": "^2.3.0",
 		"prop-types": "^15.6.0"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
-import { Animated, Dimensions, View, ViewPropTypes } from 'react-native'
+import { Animated, Dimensions, View } from 'react-native'
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 const styles = require('./styles')
 


### PR DESCRIPTION
To support RN v0.68, migrate to deprecated-react-native-prop-types to suppress warnings like this.

```
 console.warn
    ViewPropTypes will be removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'.

    > 38 | import ParallaxScrollView from 'react-native-parallax-scroll-view';
         | ^
````